### PR TITLE
Fix test dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,13 +18,11 @@ ManualMemory = "0.1.6"
 SIMDTypes = "0.1"
 Static = "0.8"
 StaticArrayInterface = "1"
+Test = "1.11.0"
 julia = "1.6"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-ArrayInterfaceOffsetArrays = "015c0d05-e682-4f19-8f0a-679ce4c54826"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ArrayInterface", "Test"]
+test = ["Test"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Fixes error in `]test`:

```
Base.PkgId(Base.UUID("10f19ff3-798f-405d-979b-55457f8fc047"), "LayoutPointers") does not declare a compat entry for the following extras:
3-element Vector{Base.PkgId}:
 Aqua [4c88cf16-eb10-579e-8560-4a9242c79595]
 ArrayInterfaceOffsetArrays [015c0d05-e682-4f19-8f0a-679ce4c54826]
 Test [8dfed614-e22c-5e08-85e1-65c5234f0b40]
Base.PkgId(Base.UUID("10f19ff3-798f-405d-979b-55457f8fc047"), "LayoutPointers") extras: Test Failed at /home/graham/.julia/packages/Aqua/tHrmY/src/deps_compat.jl:60
  Expression: isempty(result)
   Evaluated: isempty(Base.PkgId[Base.PkgId(Base.UUID("4c88cf16-eb10-579e-8560-4a9242c79595"), "Aqua"), Base.PkgId(Base.UUID("015c0d05-e682-4f19-8f0a-679ce4c54826"), "ArrayInterfaceOffsetArrays"), Base.PkgId(Base.UUID("8dfed614-e22c-5e08-85e1-65c5234f0b40"), "Test")])

Stacktrace:
 [1] macro expansion
   @ ~/.julia/juliaup/julia-1.11.0-beta1+0.x64.linux.gnu/share/julia/stdlib/v1.11/Test/src/Test.jl:679 [inlined]
 [2] test_deps_compat(pkg::Base.PkgId, deps_type::String; broken::Bool, kwargs::@Kwargs{})
   @ Aqua ~/.julia/packages/Aqua/tHrmY/src/deps_compat.jl:60
 [3] test_deps_compat
   @ ~/.julia/packages/Aqua/tHrmY/src/deps_compat.jl:55 [inlined]
 [4] macro expansion
   @ ~/.julia/packages/Aqua/tHrmY/src/deps_compat.jl:45 [inlined]
 [5] macro expansion
   @ ~/.julia/juliaup/julia-1.11.0-beta1+0.x64.linux.gnu/share/julia/stdlib/v1.11/Test/src/Test.jl:1700 [inlined]
 [6] test_deps_compat(pkg::Base.PkgId; check_julia::Bool, check_extras::Bool, check_weakdeps::Bool, kwargs::@Kwargs{})
   @ Aqua ~/.julia/packages/Aqua/tHrmY/src/deps_compat.jl:45
Grouped Strided Pointers
  0.731721 seconds (575.96 k allocations: 27.018 MiB, 3.08% gc time, 99.39% compilation time)
Test Summary:                                                                                | Pass  Fail  Total   Time
LayoutPointers.jl                                                                            |  112     1    113  14.6s
  Method ambiguity                                                                           |    1            1   2.5s
  Unbound type parameters                                                                    |    1            1   0.1s
  Undefined exports                                                                          |    1            1   0.0s
  Compare Project.toml and test/Project.toml                                                 |    1            1   0.0s
  Stale dependencies                                                                         |    1            1   1.4s
  Compat bounds                                                                              |    3     1      4   4.3s
    julia                                                                                    |    1            1   0.0s
    Base.PkgId(Base.UUID("10f19ff3-798f-405d-979b-55457f8fc047"), "LayoutPointers") deps     |    1            1   0.4s
    Base.PkgId(Base.UUID("10f19ff3-798f-405d-979b-55457f8fc047"), "LayoutPointers") extras   |          1      1   3.8s
    Base.PkgId(Base.UUID("10f19ff3-798f-405d-979b-55457f8fc047"), "LayoutPointers") weakdeps |    1            1   0.0s
  Piracy                                                                                     |    1            1   0.1s
  Persistent tasks                                                                           |    1            1   5.5s
  Grouped Strided Pointers                                                                   |  102          102   0.7s
ERROR: LoadError: Some tests did not pass: 112 passed, 1 failed, 0 errored, 0 broken.
in expression starting at /home/graham/git/LayoutPointers.jl/test/runtests.jl:30
ERROR: Package LayoutPointers errored during testing
```
